### PR TITLE
Database queues and major refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ We're not responsible for these proxies and we're not responsible for what users
 - ~~jsbeautifier==1.11.0~~ We're using a modified version of [packer.py](https://github.com/beautify-web/js-beautify/blob/master/python/jsbeautifier/unpackers/packer.py)
 
 ## TODO
-- Find a way to interrupt test-manager right after the database queue is interrupted.
-- Cleanup queries - proxies stuck on testing status + old tests + old and bad proxies.
 - Separate class to handle output of proxylists.
 - Flask Webserver:
     - Configuration to specify hostname and port to run Flask.
@@ -77,10 +75,11 @@ We're not responsible for these proxies and we're not responsible for what users
 ## Usage
 
 ```
-usage: start.py [-h] [-cf CONFIG] [-v] [--log-path LOG_PATH] [--download-path DOWNLOAD_PATH] [-pj PROXY_JUDGE] [-ua {random,chrome,firefox,safari}] --db-name DB_NAME --db-user DB_USER --db-pass DB_PASS [--db-host DB_HOST] [--db-port DB_PORT] [-Cp CLEANUP_PERIOD]
-                [-Ctc CLEANUP_TEST_COUNT] [-Cfr CLEANUP_FAIL_RATIO] [-Pf PROXY_FILE] [-Ps] [-Pp {HTTP,SOCKS4,SOCKS5}] [-Pri PROXY_REFRESH_INTERVAL] [-Psi PROXY_SCAN_INTERVAL] [-Pic [PROXY_IGNORE_COUNTRY ...]] [-Oi OUTPUT_INTERVAL] [-Ol OUTPUT_LIMIT] [-Onp]      
-                [-Oh OUTPUT_HTTP] [-Os OUTPUT_SOCKS] [-Okc OUTPUT_KINANCITY] [-Opc OUTPUT_PROXYCHAINS] [-Orm OUTPUT_ROCKETMAP] [-Mni MANAGER_NOTICE_INTERVAL] [-Mt MANAGER_TESTERS] [-Ta] [-Tp] [-Tr TESTER_RETRIES] [-Tbf TESTER_BACKOFF_FACTOR] [-Tt TESTER_TIMEOUT]
-                [-Tf] [-Sr SCRAPPER_RETRIES] [-Sbf SCRAPPER_BACKOFF_FACTOR] [-St SCRAPPER_TIMEOUT] [-Sp SCRAPPER_PROXY]
+usage: start.py [-h] [-cf CONFIG] [-v] [--log-path LOG_PATH] [--download-path DOWNLOAD_PATH] [-pj PROXY_JUDGE] [-ua {random,chrome,firefox,safari}] --db-name DB_NAME --db-user DB_USER --db-pass DB_PASS [--db-host DB_HOST]
+                [--db-port DB_PORT] [--db-max-conn DB_MAX_CONN] [--db-batch-size DB_BATCH_SIZE] [-Ca CLEANUP_AGE] [-Ctc CLEANUP_TEST_COUNT] [-Cfr CLEANUP_FAIL_RATIO] [-Pf PROXY_FILE] [-Ps] [-Pp {HTTP,SOCKS4,SOCKS5}]
+                [-Pri PROXY_REFRESH_INTERVAL] [-Psi PROXY_SCAN_INTERVAL] [-Pic [PROXY_IGNORE_COUNTRY ...]] [-Oi OUTPUT_INTERVAL] [-Ol OUTPUT_LIMIT] [-Onp] [-Oh OUTPUT_HTTP] [-Os OUTPUT_SOCKS] [-Okc OUTPUT_KINANCITY]
+                [-Opc OUTPUT_PROXYCHAINS] [-Orm OUTPUT_ROCKETMAP] [-Mni MANAGER_NOTICE_INTERVAL] [-Mt MANAGER_TESTERS] [-Ta] [-Tp] [-Tr TESTER_RETRIES] [-Tbf TESTER_BACKOFF_FACTOR] [-Tt TESTER_TIMEOUT] [-Tf] [-Sr SCRAPPER_RETRIES]      
+                [-Sbf SCRAPPER_BACKOFF_FACTOR] [-St SCRAPPER_TIMEOUT] [-Sp SCRAPPER_PROXY]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -101,14 +100,18 @@ Database:
   --db-pass DB_PASS     Password for the database. [env var: MYSQL_PASSWORD]
   --db-host DB_HOST     IP or hostname for the database. [env var: MYSQL_HOST]
   --db-port DB_PORT     Port for the database. [env var: MYSQL_PORT]
+  --db-max-conn DB_MAX_CONN
+                        Maximum number of connections to the database. [env var: MYSQL_MAX_CONN]
+  --db-batch-size DB_BATCH_SIZE
+                        Maximum number of rows to update per batch. [env var: MYSQL_BATCH_SIZE]
 
 Cleanup:
-  -Cp CLEANUP_PERIOD, --cleanup-period CLEANUP_PERIOD
-                        Check tests executed in the last X days. Default: 14.
+  -Ca CLEANUP_AGE, --cleanup-age CLEANUP_AGE
+                        Minimum proxy age in days. Default: 14.
   -Ctc CLEANUP_TEST_COUNT, --cleanup-test-count CLEANUP_TEST_COUNT
-                        Minimum number of tests to consider. Default: 30.
+                        Minimum number of tests. Default: 20.
   -Cfr CLEANUP_FAIL_RATIO, --cleanup-fail-ratio CLEANUP_FAIL_RATIO
-                        Maximum failure ratio of tests. Default: 1.
+                        Maximum failure ratio of tests. Default: 0.9.
 
 Proxy Sources:
   -Pf PROXY_FILE, --proxy-file PROXY_FILE
@@ -175,8 +178,7 @@ If an arg is specified in more than one place, then commandline values override 
 
 ## Recommendations
 
-- Use a fast AZenv proxy judge.
-- Database should be able to handle `--manager-testers / 2` connections (e.g. -Mt 100 = 50 db connnections).
+- Use fast AZenv proxy judges.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ We're not responsible for these proxies and we're not responsible for what users
 - ~~jsbeautifier==1.11.0~~ We're using a modified version of [packer.py](https://github.com/beautify-web/js-beautify/blob/master/python/jsbeautifier/unpackers/packer.py)
 
 ## TODO
-- Rework DB interactions to manually control open and close of connections:
-    - https://docs.peewee-orm.com/en/latest/peewee/database.html#connection-management
+- Find a way to interrupt test-manager right after the database queue is interrupted.
 - Cleanup queries - proxies stuck on testing status + old tests + old and bad proxies.
 - Separate class to handle output of proxylists.
 - Flask Webserver:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ We're not responsible for these proxies and we're not responsible for what users
 - ~~jsbeautifier==1.11.0~~ We're using a modified version of [packer.py](https://github.com/beautify-web/js-beautify/blob/master/python/jsbeautifier/unpackers/packer.py)
 
 ## TODO
+- Rework DB interactions to manually control open and close of connections:
+    - https://docs.peewee-orm.com/en/latest/peewee/database.html#connection-management
 - Cleanup queries - proxies stuck on testing status + old tests + old and bad proxies.
 - Separate class to handle output of proxylists.
 - Flask Webserver:
@@ -67,6 +69,7 @@ We're not responsible for these proxies and we're not responsible for what users
 - Check proxy reputation on blacklist/RBL sites (e.g: http://www.anti-abuse.org/, https://mxtoolbox.com/blacklists.aspx, https://tinycp.com/page/show/rbl-check)
 - Consider incremental sleep when testers are idle / reducing re-test cooldown period.
 - Scrapper database model to hold stats and general activity.
+- Create a statistics endpoint. Print stats at shutdown.
 - Add support for web scrapping with selenium + webdriver.
 - Resolve hostname and IP block data.
 - Separate concerns: testing, scrapping and interface/UI.

--- a/app/config/config.example.ini
+++ b/app/config/config.example.ini
@@ -4,7 +4,8 @@ db-user: admin
 db-pass: webdev
 #db-host: 127.0.0.1
 #db-port: 3306
-#max-conn: 20
+#db-max-conn: 20
+#db-batch-size: 250
 
 # Cleanup
 #cleanup-period: 14
@@ -16,7 +17,7 @@ db-pass: webdev
 #log-path: logs
 #download-path: downloads
 #tmp-path: downloads/tmp
-#proxy-judge: http://pascal.hoez.free.fr/azenv.php
+#proxy-judge: [http://pascal.hoez.free.fr/azenv.php, https://www.proxy-listen.de/azenv.php, http://www3.wind.ne.jp/hassii/env.cgi, http://ln.to/env.cgi]
 #user-agent: random
 
 # Proxy Sources

--- a/app/config/config.example.ini
+++ b/app/config/config.example.ini
@@ -8,9 +8,9 @@ db-pass: webdev
 #db-batch-size: 250
 
 # Cleanup
-#cleanup-period: 14
+#cleanup-age: 14
 #cleanup-test-count: 20
-#cleanup-fail-ratio: 1.0
+#cleanup-fail-ratio: 0.9
 
 # Misc
 #verbose: 0

--- a/app/config/config.example.ini
+++ b/app/config/config.example.ini
@@ -4,6 +4,7 @@ db-user: admin
 db-pass: webdev
 #db-host: 127.0.0.1
 #db-port: 3306
+#max-conn: 20
 
 # Cleanup
 #cleanup-period: 14

--- a/app/debug.py
+++ b/app/debug.py
@@ -16,7 +16,7 @@ from proxytools.app import App
 from proxytools.config import Config
 from proxytools.utils import configure_logging, random_ip
 
-from proxytools.models import Proxy, ProxyTest, ProxyProtocol, ProxyStatus
+from proxytools.models import Proxy, ProxyTest, ProxyProtocol, ProxyStatus, DBConfig
 
 log = logging.getLogger()
 

--- a/app/debug.py
+++ b/app/debug.py
@@ -45,7 +45,7 @@ def add_proxies(amount=1):
             'protocol': random.choices(protocols)[0]
         })
 
-    q = Proxy.insert_bulk(data)
+    q = Proxy.bulk_insert(data)
     return q
 
 
@@ -204,6 +204,6 @@ if __name__ == '__main__':
         },
     ]
 
-    Proxy.insert_bulk(proxies)
+    Proxy.bulk_insert(proxies)
     """
 

--- a/app/proxytools/app.py
+++ b/app/proxytools/app.py
@@ -55,8 +55,6 @@ class App:
             log.error('Test manager response validation failed.')
             sys.exit(1)
 
-        self.unlock_stuck()
-
         # Fetch and insert new proxies from configured sources
         self.parser.load_proxylist()
 
@@ -69,14 +67,6 @@ class App:
         self.manager.stop()
         # Stop database queue threads
         self.db_queue.stop()
-
-    def unlock_stuck(self):
-        Proxy.database().connect()
-        query = Proxy.unlock_stuck()
-        rows = query.execute()
-        Proxy.database().close()
-
-        log.info('Unlocked %d proxies stuck in testing.', rows)
 
     def __work(self):
         refresh_timer = default_timer()
@@ -95,8 +85,6 @@ class App:
                 refresh_timer = now
                 log.info('Refreshing proxylists from configured sources.')
                 self.parser.load_proxylist()
-
-                self.unlock_stuck()  # source of deadlock
 
                 # Validate proxy tester benchmark responses
                 if not self.manager.validate_responses():

--- a/app/proxytools/app.py
+++ b/app/proxytools/app.py
@@ -49,6 +49,7 @@ class App:
             log.info('Test manager response validation was successful.')
             # Start database queue threads
             self.db_queue.start()
+            time.sleep(1.0)
             # Launch proxy tester threads
             self.manager.start()
         else:

--- a/app/proxytools/app.py
+++ b/app/proxytools/app.py
@@ -96,7 +96,7 @@ class App:
                 log.info('Refreshing proxylists from configured sources.')
                 self.parser.load_proxylist()
 
-                self.unlock_stuck()
+                self.unlock_stuck()  # source of deadlock
 
                 # Validate proxy tester benchmark responses
                 if not self.manager.validate_responses():

--- a/app/proxytools/app.py
+++ b/app/proxytools/app.py
@@ -74,13 +74,12 @@ class App:
         errors = 0
 
         while True:
-            if self.manager.interrupt.is_set():
-                break
-            now = default_timer()
-
             self.db.print_stats()
             self.db_queue.print_stats()
+            if self.manager.interrupt.is_set() | self.db_queue.interrupt.is_set():
+                break
 
+            now = default_timer()
             if now > refresh_timer + self.args.proxy_refresh_interval:
                 refresh_timer = now
                 log.info('Refreshing proxylists from configured sources.')
@@ -161,6 +160,7 @@ class App:
     def __cleanup(self):
         """ Handle shutdown tasks """
         Proxy.database().close()
+        log.info('Shutdown complete.')
 
     def export(filename, proxylist, no_protocol=False):
         if not proxylist:

--- a/app/proxytools/config.py
+++ b/app/proxytools/config.py
@@ -193,12 +193,12 @@ def get_args():
 
     group = parser.add_argument_group('Cleanup')
     group.add_argument('-Ca', '--cleanup-age',
-                       help=('Minimum proxy age to cleanup. '
+                       help=('Minimum proxy age in days. '
                              'Default: 14.'),
                        default=14,
                        type=int)
     group.add_argument('-Ctc', '--cleanup-test-count',
-                       help=('Minimum number of tests to consider. '
+                       help=('Minimum number of tests. '
                              'Default: 20.'),
                        default=20,
                        type=int)

--- a/app/proxytools/config.py
+++ b/app/proxytools/config.py
@@ -192,20 +192,20 @@ def get_args():
                        type=int, default=250)
 
     group = parser.add_argument_group('Cleanup')
-    group.add_argument('-Cp', '--cleanup-period',
-                       help=('Check tests executed in the last X days. '
+    group.add_argument('-Ca', '--cleanup-age',
+                       help=('Minimum proxy age to cleanup. '
                              'Default: 14.'),
                        default=14,
                        type=int)
     group.add_argument('-Ctc', '--cleanup-test-count',
                        help=('Minimum number of tests to consider. '
-                             'Default: 30.'),
-                       default=30,
+                             'Default: 20.'),
+                       default=20,
                        type=int)
     group.add_argument('-Cfr', '--cleanup-fail-ratio',
                        help=('Maximum failure ratio of tests. '
-                             'Default: 1.'),
-                       default=1,
+                             'Default: 0.9.'),
+                       default=0.9,
                        type=float_ratio)
 
     group = parser.add_argument_group('Proxy Sources')

--- a/app/proxytools/config.py
+++ b/app/proxytools/config.py
@@ -149,6 +149,10 @@ def get_args():
                        env_var='MYSQL_PORT',
                        help='Port for the database.',
                        type=int, default=3306)
+    group.add_argument('--max-conn',
+                       env_var='MYSQL_MAX_CONN',
+                       help='Maximum number of connections to the database.',
+                       type=int, default=20)
 
     group = parser.add_argument_group('Cleanup')
     group.add_argument('-Cp', '--cleanup-period',

--- a/app/proxytools/db.py
+++ b/app/proxytools/db.py
@@ -1,0 +1,418 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import logging
+import queue
+from threading import Event, Thread
+import time
+
+from peewee import DatabaseProxy, DatabaseError, OperationalError
+from playhouse.pool import PooledMySQLDatabase, MaxConnectionsExceeded
+from playhouse.migrate import migrate, MySQLMigrator
+
+from .config import Config
+from .models import Proxy, ProxyTest, DBConfig
+
+log = logging.getLogger(__name__)
+
+
+###############################################################################
+# Database initialization
+# https://docs.peewee-orm.com/en/latest/peewee/database.html#dynamically-defining-a-database
+# https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#database-url
+# https://docs.peewee-orm.com/en/latest/peewee/database.html#setting-the-database-at-run-time
+###############################################################################
+class Database():
+    BATCH_SIZE = 250  # TODO: move to Config argparse
+    DB = DatabaseProxy()
+    MODELS = [Proxy, ProxyTest, DBConfig]
+    SCHEMA_VERSION = 1
+
+    def __init__(self):
+        """ Create a pooled connection to MySQL database """
+        self.args = Config.get_args()
+
+        log.info('Connecting to MySQL database on '
+                 f'{self.args.db_host}:{self.args.db_port}...')
+
+        # https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#pool-apis
+        database = PooledMySQLDatabase(
+            self.args.db_name,
+            host=self.args.db_host,
+            port=self.args.db_port,
+            user=self.args.db_user,
+            password=self.args.db_pass,
+            charset='utf8mb4',
+            autoconnect=False,
+            max_connections=self.args.db_max_conn,  # use None for unlimited
+            stale_timeout=180,  # use None to disable
+            timeout=10)  # 0 blocks indefinitely
+
+        # Initialize DatabaseProxy
+        self.DB.initialize(database)
+
+        # Bind models to this database
+        self.DB.bind(self.MODELS)
+
+        try:
+            self.DB.connect()
+            self.verify_database_schema()
+            self.verify_table_encoding()
+        except OperationalError as e:
+            log.error('Unable to connect to database: %s', e)
+        except DatabaseError as e:
+            log.exception('Failed to initalize database: %s', e)
+        finally:
+            self.DB.close()
+
+    #  https://docs.peewee-orm.com/en/latest/peewee/api.html#Database.create_tables
+    def create_tables(self):
+        """ Create tables in the database (skips existing) """
+        table_names = ', '.join([m.__name__ for m in self.MODELS])
+        log.info('Creating database tables: %s', table_names)
+        self.DB.create_tables(self.MODELS, safe=True)  # safe adds if not exists
+        # Create schema version key
+        DBConfig.insert_schema_version(self.SCHEMA_VERSION)
+        log.info('Database schema created.')
+
+    #  https://docs.peewee-orm.com/en/latest/peewee/api.html#Database.drop_tables
+    def drop_tables(self):
+        """ Drop all the tables in the database """
+        table_names = ', '.join([m.__name__ for m in self.MODELS])
+        log.info('Dropping database tables: %s', table_names)
+        self.DB.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
+        self.DB.drop_tables(self.MODELS, safe=True)
+        self.DB.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
+        log.info('Database schema deleted.')
+
+    # https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#schema-migrations
+    def migrate_database_schema(self, old_ver):
+        """ Migrate database schema """
+        log.info(f'Migrating schema version {old_ver} to {self.SCHEMA_VERSION}.')
+        migrator = MySQLMigrator(self.DB)
+
+        if old_ver < 2:
+            migrate(migrator.rename_table('db_config', 'db_config'))
+
+        log.info('Schema migration complete.')
+
+    def verify_database_schema(self):
+        """ Verify if database is properly initialized """
+        if not DBConfig.table_exists():
+            self.create_tables()
+            return
+
+        DBConfig.init_lock()
+        db_ver = DBConfig.get_schema_version()
+
+        # Check if schema migration is required
+        if db_ver < self.SCHEMA_VERSION:
+            self.migrate_database_schema(db_ver)
+            DBConfig.update_schema_version(self.SCHEMA_VERSION)
+        elif db_ver > self.SCHEMA_VERSION:
+            raise RuntimeError(
+                f'Unsupported schema version: {db_ver} '
+                f'(code requires: {self.SCHEMA_VERSION})')
+
+    def verify_table_encoding(self):
+        """ Verify if table collation is valid """
+        change_tables = self.DB.execute_sql(
+            'SELECT table_name FROM information_schema.tables WHERE '
+            'table_collation != "utf8mb4_unicode_ci" '
+            f'AND table_schema = "{self.args.db_name}";')
+
+        tables = self.DB.execute_sql('SHOW tables;')
+
+        if change_tables.rowcount > 0:
+            log.info('Changing collation and charset on '
+                     f'{change_tables.rowcount} tables.')
+
+            if change_tables.rowcount == tables.rowcount:
+                log.info('Changing whole database, this might a take while.')
+
+            self.DB.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
+            for table in change_tables:
+                log.debug('Changing collation and charset on '
+                          f'table {table[0]}.')
+                self.DB.execute_sql(
+                    f'ALTER TABLE {table[0]} CONVERT TO '
+                    'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;')
+            self.DB.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
+
+    def print_stats(self):
+        in_use = len(self.DB._in_use)
+        available = len(self.DB._connections)
+        log.info('Database connections: '
+                 f'{in_use} in use and {available} available.')
+
+
+class DatabaseQueue():
+    """ Singleton class that holds database queues """
+    __instance = None
+
+    @staticmethod
+    def get_db_queue():
+        """ Static access method """
+        if DatabaseQueue.__instance is None:
+            DatabaseQueue.__instance = DatabaseQueue()
+        return DatabaseQueue.__instance
+
+    def __init__(self):
+        """
+        Manage database update queues
+        """
+        if DatabaseQueue.__instance is not None:
+            raise Exception('This class is a singleton!')
+
+        self.args = Config.get_args()
+        self.interrupt = Event()
+
+        # Initialize queues
+        self.test_queue = queue.Queue(maxsize=self.args.manager_testers * 2)
+        self.proxy_queue = queue.Queue(maxsize=self.args.manager_testers * 2)
+        self.proxytest_queue = queue.Queue(maxsize=self.args.manager_testers * 10)
+
+    def start(self):
+        """
+        Start database queue threads.
+        Note: thread calling this method needs to remain alive.
+        """
+        self.test_queue_thread = Thread(
+            name='testing-queue',
+            target=self.testing_loop,
+            daemon=False)
+        self.test_queue_thread.start()
+
+        self.upsert_proxy_thread = Thread(
+            name='upsert-proxy',
+            target=self.upsert_proxy_loop,
+            daemon=False)
+        self.upsert_proxy_thread.start()
+
+        self.upsert_proxytest_thread = Thread(
+            name='upsert-proxytest',
+            target=self.upsert_proxytest_loop,
+            daemon=False)
+        self.upsert_proxytest_thread.start()
+
+    def stop(self):
+        self.interrupt.set()
+        log.info('Waiting for queue threads to finish...')
+        self.test_queue_thread.join()
+        self.upsert_proxy_thread.join()
+        self.upsert_proxytest_thread.join()
+        log.info('Database queue threads shutdown.')
+
+    def get_proxy(self):
+        try:
+            proxy = self.test_queue.get(timeout=1)
+            return proxy
+        except queue.Empty:
+            return None
+
+    def fill_test_queue(self):
+        protocol = self.args.proxy_protocol
+        num = self.test_queue.maxsize - self.test_queue.qsize()
+
+        if num == 0:
+            time.sleep(1)
+            return
+
+        if not DBConfig.lock_database(self.args.local_ip):
+            time.sleep(1)
+            return
+
+        query = Proxy.need_scan(limit=num, protocols=protocol)
+        proxy_ids = []
+        for proxy in query:
+            proxy_ids.append(proxy.id)
+            self.test_queue.put(proxy)
+
+        row_count = Proxy.bulk_lock(proxy_ids)
+        DBConfig.unlock_database(self.args.local_ip)
+        return row_count
+
+    def release_test_queue(self):
+        log.debug('Releasing proxy test queue...')
+        proxy_ids = []
+        while not self.test_queue.empty():
+            proxy = self.test_queue.get(block=False)
+            proxy_ids.append(proxy.id)
+
+        return Proxy.bulk_unlock(proxy_ids)
+
+    def update_proxy(self, proxy):
+        self.proxy_queue.put(proxy, timeout=1)
+
+    def update_proxytest(self, proxytest):
+        self.proxytest_queue.put(proxytest, timeout=1)
+
+    def upsert_proxy_queue(self, threshold=0):
+        threshold = min(self.proxy_queue.maxsize-1, threshold)
+        if self.proxy_queue.qsize() < threshold:
+            return
+
+        proxy_batch = []
+        while not self.proxy_queue.empty():
+            proxy = self.proxy_queue.get(block=False)
+            proxy_batch.append(proxy)
+
+        update_fields = [
+            'status',
+            'latency',
+            'test_count',
+            'fail_count',
+            'country',
+            'modified'
+        ]
+        Proxy.bulk_update(
+            proxy_batch,
+            fields=update_fields,
+            batch_size=Database.BATCH_SIZE)
+
+    def upsert_proxytest_queue(self, threshold=0):
+        threshold = min(self.proxytest_queue.maxsize-1, threshold)
+        if self.proxytest_queue.qsize() < threshold:
+            return
+
+        proxytest_batch = []
+        while not self.proxytest_queue.empty():
+            proxytest = self.proxytest_queue.get(block=False)
+            proxytest_batch.append(proxytest)
+
+        ProxyTest.bulk_create(proxytest_batch, batch_size=Database.BATCH_SIZE)
+
+    def print_stats(self):
+        log.info(f'Test Queue: {self.test_queue.qsize()}')
+        log.info(f'Upsert Proxy Queue: {self.proxy_queue.qsize()}')
+        log.info(f'Upsert ProxyTest Queue: {self.proxytest_queue.qsize()}')
+
+    def testing_loop(self):
+        log.debug('Test queue thread started.')
+        error_count = 0
+        while True:
+            if error_count > 4:
+                log.error('Giving up, unable to upsert Proxy queue.')
+                break
+
+            if self.interrupt.is_set():
+                break
+
+            try:
+                Proxy.database().connect()
+                self.fill_test_queue()
+                error_count = 0
+            except DatabaseError as e:
+                log.error(f'Failed to fill test queue: {e}')
+                error_count += 1
+                time.sleep(1.0)
+            except MaxConnectionsExceeded as e:
+                log.error(f'Failed to acquire a database connection: {e}')
+                error_count += 1
+                time.sleep(1.0)
+            finally:
+                Proxy.database().close()
+
+        try:
+            Proxy.database().connect()
+            self.release_test_queue()
+        except DatabaseError as e:
+            log.error(f'Failed to release test queue: {e}')
+        except MaxConnectionsExceeded as e:
+            log.error(f'Failed to acquire a database connection: {e}')
+        finally:
+            Proxy.database().close()
+
+        log.debug('Test queue thread shutdown.')
+
+    def upsert_proxy_loop(self):
+        log.debug('Proxy upsert thread started.')
+        error_count = 0
+        while True:
+            try:
+                if error_count > 4:
+                    log.error('Giving up, unable to upsert Proxy queue.')
+                    break
+                Proxy.database().connect()
+                if self.interrupt.is_set():
+                    # make sure we upsert all records
+                    self.upsert_proxy_queue()
+                else:
+                    self.upsert_proxy_queue(10)
+
+                error_count = 0
+                if self.interrupt.is_set():
+                    break
+            except DatabaseError as e:
+                log.error(f'Failed to upsert Proxy queue: {e}')
+                error_count += 1
+                time.sleep(1.0)
+            except MaxConnectionsExceeded as e:
+                log.error(f'Failed to acquire a database connection: {e}')
+                error_count += 1
+                time.sleep(1.0)
+            finally:
+                Proxy.database().close()
+
+        log.debug('Proxy upsert thread shutdown.')
+
+    def upsert_proxytest_loop(self):
+        log.debug('ProxyTest upsert thread started.')
+        error_count = 0
+        while True:
+            try:
+                if error_count > 4:
+                    log.error('Giving up, unable to upsert ProxyTest queue.')
+                Proxy.database().connect()
+                if self.interrupt.is_set():
+                    # make sure we upsert all records
+                    self.upsert_proxytest_queue()
+                else:
+                    self.upsert_proxytest_queue(10)
+
+                error_count = 0
+                if self.interrupt.is_set():
+                    break
+            except DatabaseError as e:
+                log.error(f'Failed to upsert ProxyTest queue: {e}')
+                error_count += 1
+                time.sleep(1.0)
+            except MaxConnectionsExceeded as e:
+                log.error(f'Failed to acquire a database connection: {e}')
+                error_count += 1
+                time.sleep(1.0)
+            finally:
+                Proxy.database().close()
+
+        log.debug('ProxyTest upsert thread shutdown.')
+
+    def cleanup_loop(self):
+        log.debug('Proxy cleanup thread started.')
+        while True:
+            try:
+                if self.interrupt.is_set():
+                    break
+                Proxy.database().connect()
+                Proxy.delete_failed(
+                    age_days=self.args.cleanup_period,
+                    test_count=self.args.cleanup_test_count,
+                    fail_rate=self.args.cleanup_fail_ratio,
+                    limit=10)
+                time.sleep(60)
+
+            except DatabaseError as e:
+                log.error(f'Failed to delete bad proxies: {e}')
+                if self.interrupt.is_set():
+                    break
+                time.sleep(30.0)
+            except MaxConnectionsExceeded as e:
+                log.error(f'Failed to acquire a database connection: {e}')
+                break
+            finally:
+                Proxy.database().close()
+
+        log.debug('Proxy cleanup thread shutdown.')
+
+    # TODO: create a loop to bulk_insert proxies from scrappers
+    # TODO: fix upsert queues to avoid:
+    # (1213, 'Deadlock found when trying to get lock; try restarting transaction')

--- a/app/proxytools/db.py
+++ b/app/proxytools/db.py
@@ -501,7 +501,7 @@ class CleanupThread(Thread):
             row_count = Proxy.delete_failed(
                 age_days=self.args.cleanup_age,
                 test_count=self.args.cleanup_test_count,
-                fail_rate=self.args.cleanup_fail_ratio,
+                fail_ratio=self.args.cleanup_fail_ratio,
                 limit=100)
             if row_count > 0:
                 log.debug(f'Deleted {row_count} broken proxies.')

--- a/app/proxytools/models.py
+++ b/app/proxytools/models.py
@@ -117,6 +117,9 @@ class Proxy(BaseModel):
             return (1.0 - self.fail_count / self.test_count) * 100
         return 0.0
 
+    def __repr__(self):
+        return f'{self.ip}:{self.port}'
+
     def data(self) -> dict:
         return {
             'id': self.id,
@@ -404,7 +407,7 @@ class Proxy(BaseModel):
         return count
 
     @staticmethod
-    def unlock_stuck(age_minutes=15) -> ModelUpdate:
+    def unlock_stuck(age_minutes=60) -> ModelUpdate:
         """
         Unlock proxies stuck in testing for too long.
 
@@ -496,6 +499,9 @@ class ProxyTest(BaseModel):
     latency = UIntegerField(index=True, default=0)
     info = Utf8mb4CharField(null=True)
     created = DateTimeField(index=True, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'{self.proxy}-{self.status}'
 
     @staticmethod
     def latest(exclude_ids=[]):

--- a/app/proxytools/models.py
+++ b/app/proxytools/models.py
@@ -643,8 +643,9 @@ def init_database(db_name, db_host, db_port, db_user, db_pass):
         host=db_host,
         port=db_port,
         charset='utf8mb4',
+        autoconnect=False,
         max_connections=60,  # use None for unlimited
-        stale_timeout=10,
+        stale_timeout=10,  # recycle connections
         timeout=10)  # 0 blocks indefinitely
 
     # Initialize DatabaseProxy

--- a/app/proxytools/models.py
+++ b/app/proxytools/models.py
@@ -426,7 +426,7 @@ class Proxy(BaseModel):
                  .update(status=ProxyStatus.ERROR, modified=datetime.utcnow())
                  .where(conditions))
 
-        return query
+        return query.execute()
 
     def get_failed(age_days=14, test_count=20, fail_days=7, fail_count=10) -> ModelDelete:
         """
@@ -486,9 +486,7 @@ class Proxy(BaseModel):
                  .where(conditions)
                  .limit(limit))
 
-        rowcount = query.execute()
-        log.info('Deleted %d proxies without a succesful test.', rowcount)
-        return rowcount
+        return query.execute()
 
 
 class ProxyTest(BaseModel):

--- a/app/proxytools/models.py
+++ b/app/proxytools/models.py
@@ -474,12 +474,13 @@ class Proxy(BaseModel):
             query: Deleted proxy count
         """
         min_age = datetime.utcnow() - timedelta(days=age_days)
+        fail_count = round(test_count * fail_rate)
 
         conditions = (
             (Proxy.status != ProxyStatus.TESTING) &
             (Proxy.created < min_age) &
-            (Proxy.test_count > test_count) &
-            (Proxy.fail_count / Proxy.test_count > fail_rate))
+            (Proxy.test_count >= test_count) &
+            (Proxy.fail_count >= fail_count))
 
         query = (Proxy
                  .delete()

--- a/app/proxytools/models.py
+++ b/app/proxytools/models.py
@@ -460,21 +460,21 @@ class Proxy(BaseModel):
         return query
 
     @staticmethod
-    def delete_failed(age_days=14, test_count=20, fail_rate=0.9, limit=100):
+    def delete_failed(age_days=14, test_count=20, fail_ratio=0.9, limit=100):
         """
         Delete old proxies with no success tests.
 
         Args:
             age_days (int, optional): Minimum proxy age. Defaults to 14 days.
             test_count (int, optional): Minimum number of attempts made. Defaults to 20.
-            fail_rate (float, optional): Failure rate to delete. Defaults to 0.9 (90%).
+            fail_ratio (float, optional): Failure ratio to delete. Defaults to 0.9 (90%).
             limit (int, optional): Maximum number of records deleted.
 
         Returns:
             query: Deleted proxy count
         """
         min_age = datetime.utcnow() - timedelta(days=age_days)
-        fail_count = round(test_count * fail_rate)
+        fail_count = round(test_count * fail_ratio)
 
         conditions = (
             (Proxy.status != ProxyStatus.TESTING) &

--- a/app/proxytools/proxy_parser.py
+++ b/app/proxytools/proxy_parser.py
@@ -61,5 +61,7 @@ class ProxyParser():
 
         for name, scrapper in self.scrappers.items():
             scrapper.start()
+            #for name, scrapper in self.scrappers.items():
             scrapper.join()
-            self.unregister_scrapper(scrapper)
+
+        self.scrappers.clear()

--- a/app/proxytools/proxy_parser.py
+++ b/app/proxytools/proxy_parser.py
@@ -61,7 +61,8 @@ class ProxyParser():
 
         for name, scrapper in self.scrappers.items():
             scrapper.start()
-            #for name, scrapper in self.scrappers.items():
+
+        for name, scrapper in self.scrappers.items():
             scrapper.join()
 
         self.scrappers.clear()

--- a/app/proxytools/proxy_parser.py
+++ b/app/proxytools/proxy_parser.py
@@ -16,7 +16,6 @@ class ProxyParser():
 
     def __init__(self):
         self.args = Config.get_args()
-
         args = self.args
         self.debug = args.verbose
         self.download_path = args.download_path

--- a/app/proxytools/proxy_parser.py
+++ b/app/proxytools/proxy_parser.py
@@ -57,8 +57,9 @@ class ProxyParser():
 
     def load_proxylist(self):
         if not self.scrappers:
-            return
+            self.load_scrappers()
 
         for name, scrapper in self.scrappers.items():
             scrapper.start()
             scrapper.join()
+            self.unregister_scrapper(scrapper)

--- a/app/proxytools/proxy_scrapper.py
+++ b/app/proxytools/proxy_scrapper.py
@@ -214,7 +214,7 @@ class ProxyScrapper(ABC, Thread):
             proxylist = self.scrap()
             log.info('%s scrapped a total of %d proxies.', self.name, len(proxylist))
             proxylist = self.parse_proxylist(proxylist)
-            self.db_queue.add_proxylist(proxylist)
+            self.db_queue.insert_proxylist(proxylist)
 
         except Exception as e:
             log.exception(f'{self.name} proxy scrapper failed: {e}')

--- a/app/proxytools/proxy_scrapper.py
+++ b/app/proxytools/proxy_scrapper.py
@@ -227,14 +227,12 @@ class ProxyScrapper(ABC, Thread):
     def update_database(self, proxylist):
         try:
             Proxy.database().connect()
-            Proxy.insert_bulk(proxylist)
+            Proxy.bulk_insert(proxylist, self.args.db_batch_size)
             return True
         except DatabaseError as e:
-            log.critical(f'Failed to insert scrapped proxies: {e}')
+            log.error(f'Failed to insert scrapped proxies: {e}')
         except MaxConnectionsExceeded as e:
-            log.critical(
-                f'Unable to insert scrapped proxies: {e}\n'
-                'Increase max DB connections or decrease # of threads!')
+            log.error(f'Failed to acquire a database connection: {e}')
         finally:
             Proxy.database().close()
 

--- a/app/proxytools/proxy_tester.py
+++ b/app/proxytools/proxy_tester.py
@@ -1,5 +1,4 @@
 import logging
-import random
 import time
 from datetime import datetime
 from threading import Thread
@@ -54,11 +53,14 @@ class ProxyTester(Thread):
             if self.interrupt.is_set():
                 break
 
+            if self.db_queue.interrupt.is_set():
+                break
+
             proxy = self.db_queue.get_proxy()
 
             if proxy is None:
                 log.debug('No proxy to test...')
-                time.sleep(random.uniform(10.0, 30.0))
+                time.sleep(30.0)
                 continue
 
             # Execute tests

--- a/app/proxytools/proxy_tester.py
+++ b/app/proxytools/proxy_tester.py
@@ -53,28 +53,169 @@ class ProxyTester(Thread):
             if self.manager.interrupt.is_set():
                 break
 
-            # Grab a proxy waiting for test
-            proxy = self.manager.get_proxy()
-
-            if proxy is None:
-                log.debug('No proxy to test...')
-                time.sleep(random.uniform(5.0, 15.0))
-                continue
-
             try:
+                Proxy.database().connect(reuse_if_open=True)
+                # Grab a proxy for testing
+                proxy = Proxy.get_for_scan(protocols=self.args.proxy_protocol)
+
+                if proxy is None:
+                    log.debug('No proxy to test...')
+                    time.sleep(random.uniform(5.0, 15.0))
+                    continue
+
+                # Lock proxy for testing
+                row_count = proxy.lock_for_testing()
+                if row_count != 1:
+                    log.warning(f'Failed to lock Proxy #{proxy.id} for testing.')
+                    continue
+
                 # Check if proxy should be removed
                 if self.cleanup(proxy):
                     continue
 
-            except (DatabaseError, MaxConnectionsExceeded) as e:
-                log.warning(f'Failed to acquire a database connection: {e}')
-                time.sleep(random.uniform(5.0, 15.0))
-                continue
+            except DatabaseError as e:
+                log.critical(f'Failed to update Proxy #{proxy.id}: {e}')
+            except MaxConnectionsExceeded as e:
+                log.critical(
+                    f'Failed to acquire a database connection: {e}\n'
+                    'Increase max DB connections or decrease # of threads!')
+                break
+            finally:
+                Proxy.database().close()
 
             # Execute tests
-            self.execute_tests(proxy)
+            results = self.execute_tests(proxy)
 
+            # Update database with test results
+
+            if not self.update_database(proxy, results):
+                break
+
+        Proxy.database().close()
         log.debug(f'{self.name} shutdown.')
+
+    def cleanup(self, proxy: Proxy) -> bool:
+        """
+        Tests if proxy is old and not worth testing.
+
+        Args:
+            proxy (Proxy): proxy being tested
+
+        Returns:
+            bool: True if proxy was deleted, False otherwise
+        """
+        analysis_period = self.args.cleanup_period
+        min_age = datetime.utcnow() - timedelta(days=analysis_period)
+
+        # Do not evaluate proxies before a cleanup period has passed
+        if proxy.created > min_age:
+            return False
+
+        # Check test count during cleanup period
+        test_count = ProxyTest.all_tests(proxy.id, age_days=analysis_period).count()
+        if test_count < self.args.cleanup_test_count:
+            return False
+
+        # Check fail ratio during cleanup period
+        fail_count = ProxyTest.failed_tests(proxy.id, age_days=analysis_period).count()
+        fail_ratio = fail_count / test_count
+        if fail_ratio < self.args.cleanup_fail_ratio:
+            return False
+
+        return self.delete_proxy(proxy)
+
+    def delete_proxy(self, proxy: Proxy):
+        row_count = proxy.delete_instance()
+        if row_count != 1:
+            log.warning(f'Failed to delete Proxy #{proxy.id}.')
+            return False
+
+        log.info(f'Deleted Proxy #{proxy.id} - failed '
+                 f'{proxy.fail_count} out of {proxy.test_count} tests.')
+        return True
+
+    def evaluate_results(self, proxy: Proxy, results: list) -> None:
+        """
+        Update proxy model object with data from test results.
+
+        Args:
+            proxy (Proxy): proxy that was tested
+            results (list(ProxyTest)): proxy test results
+        """
+        if proxy.country is None:
+            country = self.manager.ip2location.lookup_country(proxy.ip)
+            proxy.country = country
+
+        total_latency = 0
+        for proxy_test in results:
+            total_latency += proxy_test.latency
+
+        proxy.latency = int(total_latency / len(results))
+        proxy.status = results[-1].status
+        proxy.modified = datetime.utcnow()
+
+    def update_stats(self, proxy: Proxy, proxy_test: ProxyTest) -> None:
+        """
+        Notify manager with test results.
+
+        Args:
+            proxy (Proxy): proxy being tested
+            proxy_test (ProxyTest): test results
+        """
+        proxy.test_count += 1
+        if proxy_test.status != ProxyStatus.OK:
+            self.manager.mark_fail()
+            proxy.fail_count += 1
+        else:
+            self.manager.mark_success()
+
+    def update_database(self, proxy: Proxy, results: list) -> bool:
+        """
+        Update database with new test results.
+
+        Args:
+            proxy (Proxy): proxy being tested
+            results (list(ProxyTest)): proxy test results
+        """
+        try:
+            proxy.database().connect()
+
+            for proxy_test in results:
+                if proxy_test.is_dirty():
+                    proxy_test.save()
+
+            proxy.save()
+            log.debug(
+                f'Updated Proxy #{proxy.id} - {proxy.url()} - '
+                f'({proxy.latency}ms - {proxy.country}) - '
+                f'{proxy.test_score():.2f}% ({proxy.test_count} tests)')
+            return True
+        except DatabaseError as e:
+            log.critical(f'Failed to update Proxy #{proxy.id}: {e}')
+        except MaxConnectionsExceeded as e:
+            log.critical(
+                f'Unable to update database: {e}\n'
+                'Increase max DB connections or decrease # of threads!')
+        finally:
+            proxy.database().close()  # force connection recycling
+
+        return False
+
+    def update(self, proxy: Proxy, results: list) -> bool:
+        """
+        Update proxy and test data with results.
+
+        Args:
+            proxy (Proxy): proxy being tested
+            results (list(ProxyTest)): proxy test results
+        """
+        self.evaluate_results(proxy, results)
+        for i in range(5):
+            if self.update_database(proxy, results):
+                return True
+            time.sleep(3.0)
+
+        return False
 
     def execute_tests(self, proxy: Proxy):
         results = []
@@ -85,6 +226,7 @@ class ProxyTester(Thread):
                     log.debug('Skipped %s test for proxy: %s', test.name, proxy.url())
                     continue
 
+                # log.debug(f'Running test {test.name} on Proxy #{proxy.id}: {proxy.url()}')
                 proxy_test = test.run(proxy)
                 if not proxy_test:
                     log.error('Proxy test %s returned no results.', test_name)
@@ -113,125 +255,4 @@ class ProxyTester(Thread):
                 info='Not tested',
                 status=ProxyStatus.ERROR))
 
-        self.update(proxy, results)
-
-    def update_stats(self, proxy: Proxy, proxy_test: ProxyTest) -> None:
-        """
-        Notify manager with test results.
-
-        Args:
-            proxy (Proxy): proxy being tested
-            proxy_test (ProxyTest): test results
-        """
-        proxy.test_count += 1
-        if proxy_test.status != ProxyStatus.OK:
-            self.manager.mark_fail()
-            proxy.fail_count += 1
-        else:
-            self.manager.mark_success()
-
-    def cleanup(self, proxy: Proxy) -> bool:
-        analysis_period = self.args.cleanup_period
-        min_age = datetime.utcnow() - timedelta(days=analysis_period)
-
-        # Do not evaluate proxies before a cleanup period has passed
-        if proxy.created > min_age:
-            return False
-
-        # Check test count during cleanup period
-        test_count = ProxyTest.all_tests(proxy.id, age_days=analysis_period).count()
-        if test_count < self.args.cleanup_test_count:
-            return False
-
-        # Check fail ratio during cleanup period
-        fail_count = ProxyTest.failed_tests(proxy.id, age_days=analysis_period).count()
-        fail_ratio = fail_count / test_count
-        if fail_ratio < self.args.cleanup_fail_ratio:
-            return False
-
-        row_count = proxy.delete_instance()
-        proxy.database().close()
-
-        if row_count != 1:
-            log.warning(f'Failed to delete Proxy #{proxy.id}.')
-            return True
-
-        log.debug(f'Deleted Proxy #{proxy.id} - '
-                  f'failed {fail_ratio*100:.2f}% ({fail_count} / {test_count}).')
-
-        return True
-
-    def evaluate_results(self, proxy: Proxy, results: list) -> None:
-        """
-        Update proxy model object with data from test results.
-
-        Args:
-            proxy (Proxy): proxy that was tested
-            results (list(ProxyTest)): proxy test results
-        """
-        if proxy.country is None:
-            country = self.manager.ip2location.lookup_country(proxy.ip)
-            proxy.country = country
-
-        total_latency = 0
-        for proxy_test in results:
-            total_latency += proxy_test.latency
-
-        proxy.latency = int(total_latency / len(results))
-        proxy.status = results[-1].status
-        proxy.modified = datetime.utcnow()
-
-    def update_database(self, proxy: Proxy, results: list) -> None:
-        """
-        Update database with new test results.
-
-        Args:
-            proxy (Proxy): proxy being tested
-            results (list(ProxyTest)): proxy test results
-        """
-        for proxy_test in results:
-            if not proxy_test.is_dirty():
-                log.debug(f'Skipped already saved test #{proxy_test.id}')
-                continue
-
-            try:
-                proxy_test.save()
-            except (DatabaseError, MaxConnectionsExceeded) as e:
-                log.warn(f'Failed to insert ProxyTest: {e}')
-                return False
-        try:
-            proxy.save()
-            proxy.database().close()
-        except (DatabaseError, MaxConnectionsExceeded) as e:
-            log.warn(f'Failed to update Proxy #{proxy.id}: {e}')
-            return False
-
-        return True
-
-    def update(self, proxy: Proxy, results: list) -> None:
-        """
-        Update proxy with test results.
-
-        Args:
-            proxy (Proxy): proxy being tested
-            results (list(ProxyTest)): proxy test results
-        """
-        self.evaluate_results(proxy, results)
-
-        failed = True
-        for i in range(5):
-            if self.update_database(proxy, results):
-                failed = False
-                break
-
-            if i < 4:
-                time.sleep(random.uniform(2.0, 5.0))
-
-        if failed:
-            log.critical('Increase max DB connections or decrease # of threads!')
-            return
-
-        log.debug(f'Updated Proxy #{proxy.id} - '
-                  f'{results[-1].info}: {proxy.url()} - '
-                  f'({proxy.latency}ms - {proxy.country}) - '
-                  f'{proxy.test_score():.2f}% ({proxy.test_count} tests)')
+        return results

--- a/app/proxytools/proxy_tester.py
+++ b/app/proxytools/proxy_tester.py
@@ -224,6 +224,9 @@ class ProxyTester(Thread):
                 failed = False
                 break
 
+            if i < 4:
+                time.sleep(random.uniform(2.0, 5.0))
+
         if failed:
             log.critical('Increase max DB connections or decrease # of threads!')
             return

--- a/app/proxytools/scrappers/geonode.py
+++ b/app/proxytools/scrappers/geonode.py
@@ -3,6 +3,8 @@
 
 import logging
 import math
+import random
+import time
 
 from ..models import ProxyProtocol
 from ..proxy_scrapper import ProxyScrapper
@@ -57,6 +59,8 @@ class GeoNode(ProxyScrapper):
             log.info('Parsing proxylist from webpage: %s', url)
             for row in json.get('data', []):
                 proxylist.append(f'{row["ip"]}:{row["port"]}')
+
+            time.sleep(random.uniform(2.0, 4.0))
 
         self.session.close()
         log.info('Parsed %d proxies from webpage.', len(proxylist))

--- a/app/proxytools/test.py
+++ b/app/proxytools/test.py
@@ -29,10 +29,11 @@ class Test(ABC):
         self.args = Config.get_args()
         self.manager = manager
         self.name = name
+        self.proxy_judge = Config.get_proxyjudge()
+
         self.user_agent = UserAgent.generate(self.args.user_agent)
         self.headers = http_headers()
         self.headers['User-Agent'] = self.user_agent
-        self.local_ip = manager.local_ip
 
         # https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html
         self.urlib3_retry = urllib3.Retry(

--- a/app/proxytools/test_manager.py
+++ b/app/proxytools/test_manager.py
@@ -198,16 +198,7 @@ class TestManager():
 
             # Print statistics regularly
             if now >= notice_timer + self.args.manager_notice_interval:
-                log.info('Total tests: %d valid and %d failed.',
-                         self.total_success, self.total_fail)
-                log.info('Tests in last %ds: %d valid and %d failed.',
-                         self.args.manager_notice_interval,
-                         self.notice_success, self.notice_fail)
-                db_stats = get_connection_stats()
-                log.debug('Database connections: %d in use and %d available.',
-                          db_stats[0], db_stats[1])
-                log.debug('%d proxies queued for testing.', self.queue.qsize())
-
+                self.print_stats()
                 notice_timer = now
                 self.reset_notice_stats()
 
@@ -220,3 +211,14 @@ class TestManager():
             time.sleep(5)
 
         self.release_queue()
+
+    def print_stats(self):
+        log.info('Total tests: %d valid and %d failed.',
+                 self.total_success, self.total_fail)
+        log.info('Tests in last %ds: %d valid and %d failed.',
+                 self.args.manager_notice_interval,
+                 self.notice_success, self.notice_fail)
+        db_stats = get_connection_stats()
+        log.debug('Database connections: %d in use and %d available.',
+                  db_stats[0], db_stats[1])
+        log.debug('%d proxies queued for testing.', self.queue.qsize())

--- a/app/proxytools/test_manager.py
+++ b/app/proxytools/test_manager.py
@@ -91,7 +91,7 @@ class TestManager():
 
     def launch_testers(self):
         self.tester_threads = []
-        time.sleep(5.0)
+        time.sleep(1.0)
         for id in range(self.args.manager_testers):
             tester_thread = ProxyTester(id, self)
             self.tester_threads.append(tester_thread)

--- a/app/proxytools/testers/azenv.py
+++ b/app/proxytools/testers/azenv.py
@@ -18,7 +18,7 @@ class AZenv(Test):
 
     def __init__(self, manager):
         super().__init__(manager, 'azenv')
-        self.base_url = self.args.proxy_judge
+        self.base_url = self.proxy_judge
 
     def skip_test(self, proxy: Proxy) -> bool:
         return False
@@ -140,7 +140,7 @@ class AZenv(Test):
 
         # search for local IP
         for value in headers.values():
-            if self.local_ip in value:
+            if self.args.local_ip in value:
                 proxy_test.status = ProxyStatus.ERROR
                 proxy_test.info = 'Non-anonymous proxy'
                 return False

--- a/app/proxytools/utils.py
+++ b/app/proxytools/utils.py
@@ -68,6 +68,10 @@ def configure_logging(log, verbosity=0, output_path='logs', output_name='-app'):
     if verbosity > 1:
         logging.getLogger('peewee.pool').setLevel(logging.DEBUG)
 
+        # Monitor hanging threads
+        from hanging_threads import start_monitoring
+        start_monitoring()
+
 
 def sigterm_handler(_signo, _stack_frame):
     sys.exit(0)

--- a/app/proxytools/utils.py
+++ b/app/proxytools/utils.py
@@ -64,6 +64,9 @@ def configure_logging(log, verbosity=0, output_path='logs', output_name='-app'):
         logging.getLogger('requests').setLevel(logging.WARNING)
         logging.getLogger('urllib3').setLevel(logging.ERROR)
 
+    if verbosity > 1:
+        logging.getLogger('peewee.pool').setLevel(logging.DEBUG)
+
 
 def sigterm_handler(_signo, _stack_frame):
     sys.exit(0)

--- a/app/webserver.py
+++ b/app/webserver.py
@@ -138,7 +138,8 @@ if __name__ == '__main__':
             args.db_host,
             args.db_port,
             args.db_user,
-            args.db_pass)
+            args.db_pass,
+            args.db_max_conn)
 
         log.info('Starting up...')
         # Note: Flask reloader runs two processes


### PR DESCRIPTION
Changed back to an approach where a couple of threads handle all database queries, batching database operations together for efficiency.
- Easily capable of handling hundreds of tester threads.
- Only uses a couple of database connections.
- Better algorithm to select queries for testing.
- Mechanism to lock database when grabbing proxies for testing.
  - This enables sharing one database with multiple instances, without overlapping tests.
- Support for a list of Proxy Judges which are cycled by testers and validated at initialization.